### PR TITLE
Keep dependency version info when updating DESCRIPTION

### DIFF
--- a/R/write_dependencies.r
+++ b/R/write_dependencies.r
@@ -17,12 +17,21 @@
 #' }
 write_dependencies <- function(pkg = ".") {
   pkg <- devtools::as.package(pkg)
+
+  # get dependencies mentioned in package source or NAMESPACE
   packages <- get_dependencies(pkg = pkg)
   if (length(packages) > 0) {
-    deps <- data.frame(type = "Imports", package = packages, version = "*")
+    updated_deps <- data.frame(type = "Imports", package = packages)
   } else {
-    deps <- data.frame(type = character(0), package = character(0), version = character(0))
+    updated_deps <- data.frame(type = character(0), package = character(0))
   }
+  # get dependencies already declared in DESCRIPTION
+  existing_deps <- desc::desc_get_deps(pkg$path)
+  # keep version numbers from pre-existing dependencies
+  deps <- merge(existing_deps, updated_deps, all.y = TRUE)
+  # dependencies with no version info (i.e. new dependencies or not specified) match anything
+  deps$version[is.na(deps$version)] <- "*"
+
   message("Updating ", pkg$package, " DESCRIPTION")
   desc::desc_set_deps(deps, file = pkg$path)
 }


### PR DESCRIPTION
It would be useful for pkghelper to leave pre-existing versions in the DESCRIPTION file as they were before running write_dependencies. At the moment it resets them all to have no version constraint.

This PR makes pkghelper leave existing version constraints alone. New packages will still be added with no version constraint, but you can manually edit the DESCRIPTION file after running write_dependencies to add one in. A nice next step would be to add something like #1.